### PR TITLE
feat: add qubership-profiler-agent to the image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /.idea
+/local-artifacts
+!/local-artifacts/README.md

--- a/Dockerfile.java-alpine
+++ b/Dockerfile.java-alpine
@@ -77,11 +77,36 @@ RUN mkdir /app && \
     chown -R 10001:0 /app/volumes && \
     find /app \( -type d -exec chmod ug+rwx {} \; -exec chown 10001:0 {} \; -o -type f -exec chmod ug+rw {} \; -exec chown 10001:0 {} \; \)
 
+ARG QUBERSHIP_PROFILER_VERSION=1.0.4
+ARG MAVEN_CENTRAL_URL=https://repo.maven.apache.org/maven2
+# Supported values are: local, remote. Local artifact enables testing the dockerfile without publishing the profiler to Central.
+ARG QUBERSHIP_PROFILER_ARTIFACT_SOURCE=remote
+
+RUN --mount=type=bind,source=local-artifacts,target=/build/artifacts mkdir /app/diag && \
+    cd /app/diag && \
+    if [ "$QUBERSHIP_PROFILER_ARTIFACT_SOURCE" = "local" ]; then \
+      cp "/build/artifacts/qubership-profiler-installer-$QUBERSHIP_PROFILER_VERSION.zip" .; \
+    elif [ "$QUBERSHIP_PROFILER_ARTIFACT_SOURCE" = "remote" ]; then \
+      curl --fail-with-body -OL "$MAVEN_CENTRAL_URL/org/qubership/profiler/qubership-profiler-installer/$QUBERSHIP_PROFILER_VERSION/qubership-profiler-installer-$QUBERSHIP_PROFILER_VERSION.zip"; \
+    else \
+      echo "Unsupported QUBERSHIP_PROFILER_ARTIFACT_SOURCE=$QUBERSHIP_PROFILER_ARTIFACT_SOURCE. Supported values are local, remote"; \
+      exit 127; \
+    fi && \
+    unzip "qubership-profiler-installer-$QUBERSHIP_PROFILER_VERSION.zip" && \
+    rm "qubership-profiler-installer-$QUBERSHIP_PROFILER_VERSION.zip" && \
+    chown -R 10001:0 /app/diag
+
 VOLUME /tmp
 VOLUME /etc/env
 VOLUME /app/nss
 VOLUME /etc/ssl/certs/java
 VOLUME /etc/secret
+
+RUN mkdir /app/diag/dump && \
+    chmod ug+rw -R /app/diag && \
+    chown -R 10001:0 /app/diag
+
+VOLUME /app/diag/dump
 
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -130,8 +130,18 @@ if [[ "$1" != "bash" ]] && [[ "$1" != "sh" ]] ; then
     echo "run init scripts"
     run_init_scripts
     for sig in $SIGNALS_TO_RETHROW; do trap 'rethrow_handler "$sig"' "$sig" > /dev/null 2>&1; done
-    echo "Run subcommand:" "$@"
-    $@ &
+    if [[ "$1" == "java" || "$1" == "/usr/bin/java" ]]; then
+      shift # trim "java"
+      if [[ "${PROFILER_ENABLED,,}" == "true" ]]; then
+        JAVA_OPTIONS="$JAVA_OPTIONS -javaagent:/app/diag/lib/qubership-profiler-agent.jar"
+        JAVA_OPTIONS="$JAVA_OPTIONS -Dprofiler.dump.home=/app/diag"
+      fi
+      echo "Run command:" java "$JAVA_OPTIONS" "$@"
+      java $JAVA_OPTIONS $@ &
+    else
+      echo "Run subcommand:" "$@"
+      $@ &
+    fi
     pid="$!"
     wait "$pid" ; retCode=$?
     echo "Process ended with return code ${retCode}"

--- a/local-artifacts/README.md
+++ b/local-artifacts/README.md
@@ -1,0 +1,18 @@
+# Local Artifacts
+
+This directory is used for storing and referencing local Maven artifacts during testing and development. Instead of
+pulling dependencies from remote Maven repositories, you can place artifact files here to be used directly.
+
+## Usage
+
+1. Place artifacts in this directory
+2. Add `ARG` in the corresponding `Dockerfile` so it selects the artifact source (`local`, `remote`)
+3. Use `RUN --mount=type=bind,source=local-artifacts,destination=...` to access the artifacts when source artifact selects `local` mode
+
+This approach allows testing with unpublished artifacts and speeds up development by avoiding remote downloads.
+
+## Best Practices
+
+- Only use for testing/development
+- Do not commit binary artifacts to version control
+- Document any special artifact requirements


### PR DESCRIPTION
It enables profiling Java applications.
The profiler could be enabled via QUBERSHIP_PROFILER_ENABLE=true environment variable

Here's the CI test at the profiler side:
* https://github.com/Netcracker/qubership-profiler-agent/pull/151

Here's the published `installer.zip`:
* https://repo1.maven.org/maven2/org/qubership/profiler/qubership-profiler-installer/1.0.4/