### PR TITLE
feat: include kubernetes service account ca.crt if exists when loading

### DIFF
--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -60,7 +60,7 @@ jobs:
         run: |
           openssl genpkey -algorithm RSA -out testcert_key.pem -pkeyopt rsa_keygen_bits:2048
           openssl req -x509 -newkey rsa:2048 -keyout testcert_key.pem -out testcert.pem -days 365 -nodes -subj "/CN=testcerts.com"
-          openssl req -x509 -key testcert_key.pem -out test-k8s-ca.crt -days 365 -nodes -subj "/CN=kubernetes"
+          openssl req -x509 -key testcert_key.pem -out test-k8s-ca.crt -days 365 -nodes -subj "/CN=testcerts.com"
           mkdir certs
           mv testcert.pem certs/
 
@@ -71,12 +71,12 @@ jobs:
 
       - name: Validate ca certificates were copied to store
         run: |
-          docker run -v ./certs/:/tmp/cert/ --rm ghcr.io/netcracker/qubership/core-base:test ls -l /etc/ssl/certs/*testcert* 
+          docker run -v ./certs/:/tmp/cert/ --rm ghcr.io/netcracker/qubership/core-base:test cat /etc/ssl/certs/ca-certificates.crt | awk -v decoder='openssl x509 -noout -subject -enddate 2>/dev/null' '/BEGIN/{close(decoder)};{print | decoder}' | grep testcerts.com
 
       - name: Validate kubernetes ca certificate
         run: |
-          docker run -v ./certs/:/tmp/cert/ -v ./test-k8s-ca.crt:/var/run/secrets/kubernetes.io/serviceaccount/ca.crt --rm ghcr.io/netcracker/qubership/core-base:test cat /etc/ssl/certs/ca-certificates.crt | awk -v decoder='openssl x509 -noout -subject -enddate 2>/dev/null' '/BEGIN/{close(decoder)};{print | decoder}' | grep kubernetes
-          docker run -v ./certs/:/tmp/cert/ -v ./test-k8s-ca.crt:/var/run/secrets/kubernetes.io/serviceaccount/ca.crt --rm ghcr.io/netcracker/qubership/java-base:test keytool -cacerts -storepass changeit -list | grep ca.crt
+          docker run -v ./test-k8s-ca.crt:/var/run/secrets/kubernetes.io/serviceaccount/ca.crt --rm ghcr.io/netcracker/qubership/core-base:test cat /etc/ssl/certs/ca-certificates.crt | awk -v decoder='openssl x509 -noout -subject -enddate 2>/dev/null' '/BEGIN/{close(decoder)};{print | decoder}' | grep testcerts.com
+          docker run -v ./test-k8s-ca.crt:/var/run/secrets/kubernetes.io/serviceaccount/ca.crt --rm ghcr.io/netcracker/qubership/java-base:test keytool -cacerts -storepass changeit -v -list | grep testcerts.com
 
 
       - name: Build and push java-image

--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -60,6 +60,7 @@ jobs:
         run: |
           openssl genpkey -algorithm RSA -out testcert_key.pem -pkeyopt rsa_keygen_bits:2048
           openssl req -x509 -newkey rsa:2048 -keyout testcert_key.pem -out testcert.pem -days 365 -nodes -subj "/CN=testcerts.com"
+          openssl req -x509 -key testcert_key.pem -out test-k8s-ca.crt -days 365 -nodes -subj "/CN=kubernetes"
           mkdir certs
           mv testcert.pem certs/
 
@@ -72,9 +73,9 @@ jobs:
         run: |
           docker run -v ./certs/:/tmp/cert/ --rm ghcr.io/netcracker/qubership/core-base:test ls -l /etc/ssl/certs/*testcert* 
 
-      - name: Validate kubernetes ca certificate was copied
+      - name: Validate kubernetes ca certificate
         run: |
-          docker run -v ./certs/:/tmp/cert/ --rm ghcr.io/netcracker/qubership/core-base:test ls -l ls -l "CERTIFICATE_FILE_LOCATION/ca.crt"
+          docker run -v ./certs/:/tmp/cert/ -v ./test-k8s-ca.crt:/var/run/secrets/kubernetes.io/serviceaccount/ca.crt --rm ghcr.io/netcracker/qubership/java-base:test keytool -ca-certs -storepass changeit -list | grep ca.crt
 
 
       - name: Build and push java-image

--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -72,6 +72,10 @@ jobs:
         run: |
           docker run -v ./certs/:/tmp/cert/ --rm ghcr.io/netcracker/qubership/core-base:test ls -l /etc/ssl/certs/*testcert* 
 
+      - name: Validate kubernetes ca certificate was copied
+        run: |
+          docker run -v ./certs/:/tmp/cert/ --rm ghcr.io/netcracker/qubership/core-base:test ls -l ls -l "CERTIFICATE_FILE_LOCATION/ca.crt"
+
 
       - name: Build and push java-image
         uses: docker/build-push-action@v6

--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Validate kubernetes ca certificate
         run: |
-          docker run -v ./certs/:/tmp/cert/ -v ./test-k8s-ca.crt:/var/run/secrets/kubernetes.io/serviceaccount/ca.crt --rm ghcr.io/netcracker/qubership/java-base:test keytool -ca-certs -storepass changeit -list | grep ca.crt
+          docker run -v ./certs/:/tmp/cert/ -v ./test-k8s-ca.crt:/var/run/secrets/kubernetes.io/serviceaccount/ca.crt --rm ghcr.io/netcracker/qubership/java-base:test keytool -cacerts -storepass changeit -list | grep ca.crt
 
 
       - name: Build and push java-image

--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -75,6 +75,7 @@ jobs:
 
       - name: Validate kubernetes ca certificate
         run: |
+          docker run -v ./certs/:/tmp/cert/ -v ./test-k8s-ca.crt:/var/run/secrets/kubernetes.io/serviceaccount/ca.crt --rm ghcr.io/netcracker/qubership/core-base:test cat /etc/ssl/certs/ca-certificates.crt | awk -v decoder='openssl x509 -noout -subject -enddate 2>/dev/null' '/BEGIN/{close(decoder)};{print | decoder}' | grep kubernetes
           docker run -v ./certs/:/tmp/cert/ -v ./test-k8s-ca.crt:/var/run/secrets/kubernetes.io/serviceaccount/ca.crt --rm ghcr.io/netcracker/qubership/java-base:test keytool -cacerts -storepass changeit -list | grep ca.crt
 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,12 +3,7 @@
 load_certificates() {
     export certs_location="${CERTIFICATE_FILE_LOCATION}"
     # shellcheck disable=SC2016
-    certs_found=$(find /tmp/cert -type f \( -name '*.crt' -o -name '*.cer' -o -name '*.pem' \))
-    k8s_ca_cert="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-    if [ -f "$k8s_ca_cert" ]; then
-      cp "$k8s_ca_cert" "/tmp/k8s-ca.crt"
-      certs_found="$certs_found"$'\n'"/tmp/k8s-ca.crt"
-    fi
+    certs_found=$(find /tmp/cert /var/run/secrets/kubernetes.io/serviceaccount -type f \( -name '*.crt' -o -name '*.cer' -o -name '*.pem' \))
     if which keytool; then
       echo "Load certificates to java keystore"
       export pass=${CERTIFICATE_FILE_PASSWORD:-changeit}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 
 load_certificates() {
-    k8s_ca_cert="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-    if [ -f "$k8s_ca_cert" ]; then
-      mkdir -p "/tmp/cert"
-      cp "$k8s_ca_cert" "/tmp/cert"
-    fi
     export certs_location="${CERTIFICATE_FILE_LOCATION}"
     # shellcheck disable=SC2016
     certs_found=$(find /tmp/cert -type f \( -name '*.crt' -o -name '*.cer' -o -name '*.pem' \))
+    k8s_ca_cert="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    if [ -f "$k8s_ca_cert" ]; then
+      cp "$k8s_ca_cert" "/tmp/k8s-ca.crt"
+      certs_found="$certs_found"$'\n'"/tmp/k8s-ca.crt"
+    fi
     if which keytool; then
       echo "Load certificates to java keystore"
       export pass=${CERTIFICATE_FILE_PASSWORD:-changeit}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,15 @@
 load_certificates() {
     export certs_location="${CERTIFICATE_FILE_LOCATION}"
     # shellcheck disable=SC2016
-    certs_found=$(find /tmp/cert /var/run/secrets/kubernetes.io/serviceaccount -type f \( -name '*.crt' -o -name '*.cer' -o -name '*.pem' \))
+
+    cert_search_dirs="/tmp/cert"
+    kube_cert_dir="/var/run/secrets/kubernetes.io/serviceaccount"
+
+    if [ -d "$kube_cert_dir" ]; then
+      cert_search_dirs="$cert_search_dirs $kube_cert_dir"
+    fi
+    certs_found=$(find $cert_search_dirs -type f \( -name '*.crt' -o -name '*.cer' -o -name '*.pem' \))
+
     if which keytool; then
       echo "Load certificates to java keystore"
       export pass=${CERTIFICATE_FILE_PASSWORD:-changeit}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 
 load_certificates() {
-
+    k8s_ca_cert="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    if [ -f "$k8s_ca_cert" ]; then
+      mkdir -p "/tmp/cert"
+      cp "$k8s_ca_cert" "/tmp/cert"
+    fi
     export certs_location="${CERTIFICATE_FILE_LOCATION}"
     # shellcheck disable=SC2016
     certs_found=$(find /tmp/cert -type f \( -name '*.crt' -o -name '*.cer' -o -name '*.pem' \))


### PR DESCRIPTION
certificates








<!-- start messages -->
### Commit messages:
[nurtai325](https://github.com/Netcracker/qubership-core-base-images/commit/95c41c5146d6518f60aa3f61700c80cb779ec9be) feat: include kubernetes service account ca.crt if exists when loading
certificates
[nurtai325](https://github.com/Netcracker/qubership-core-base-images/commit/ff946a1cd20197ae16d93e547dea828355f83cc4) fix: instead of copying k8s ca cert to /tmp/cert append to certs_found
variable
[nurtai325](https://github.com/Netcracker/qubership-core-base-images/commit/ae5d089c4295a7ab9ccd3f5bf7799d7934156e6c) reuse find command instead of creating a temp file. add k8s
serviceaccount dir to args
[nurtai325](https://github.com/Netcracker/qubership-core-base-images/commit/e1656ad6d3d75dd95c5018f01d821687becf0785) test for kubernetes cert copied
[nurtai325](https://github.com/Netcracker/qubership-core-base-images/commit/88b67b008a6335a274d88307667451ca67310333) fix: only include k8s sa dir when updating certs if it exists
[nurtai325](https://github.com/Netcracker/qubership-core-base-images/commit/016fea810b724f3945a6c978626c510ad36f82a1) fix: generate ca cert for kubernetes and validate that it was added in
java-base
[nurtai325](https://github.com/Netcracker/qubership-core-base-images/commit/e36781cf7083e7e110d4ba3807357e53df447189) fix: typo in tests
[nurtai325](https://github.com/Netcracker/qubership-core-base-images/commit/4cf9debb50f27b0e4478fc3513cab9ba34a78adf) fix: k8s ca-cert test for core-base
[nurtai325](https://github.com/Netcracker/qubership-core-base-images/commit/5223f2d305183f0c7c113708413ce436808e3fe2) fix: k8s certs testing grep not filename but subject using keytool with
-v verbose option. fix previous test too
<!-- end messages -->








