### PR TITLE
chore: bump org.qubership.profiler to 3.0.0

### DIFF
--- a/Dockerfile.java-alpine
+++ b/Dockerfile.java-alpine
@@ -80,7 +80,7 @@ RUN mkdir /app && \
     chown -R 10001:0 /app/volumes && \
     find /app \( -type d -exec chmod ug+rwx {} \; -exec chown 10001:0 {} \; -o -type f -exec chmod ug+rw {} \; -exec chown 10001:0 {} \; \)
 
-ARG QUBERSHIP_PROFILER_VERSION=2.0.3
+ARG QUBERSHIP_PROFILER_VERSION=3.0.0
 ARG MAVEN_CENTRAL_URL=https://repo.maven.apache.org/maven2
 # Supported values are: local, remote. Local artifact enables testing the dockerfile without publishing the profiler to Central.
 ARG QUBERSHIP_PROFILER_ARTIFACT_SOURCE=remote

--- a/test-profiler/pom.xml
+++ b/test-profiler/pom.xml
@@ -8,19 +8,6 @@
     <properties>
         <qubership.profiler.java-base-image.tag>qubership/qubership-core-base-image:profiler-latest</qubership.profiler.java-base-image.tag>
     </properties>
-    <dependencyManagement>
-        <dependencies>
-            <!-- Explicit dependency on commons-lang3 is needed to workaround https://issues.apache.org/jira/browse/MNG-7852
-                 Otherwise Maven resolves to older commons-lang3:3.12.0, and the build fails with
-                  java.lang.NoClassDefFoundError: org/apache/commons/lang3/ArrayFill
-            -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>3.18.0</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -36,12 +23,12 @@
         <dependency>
             <groupId>org.qubership.profiler</groupId>
             <artifactId>qubership-profiler-mock-collector</artifactId>
-            <version>2.0.3</version>
+            <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.qubership.profiler</groupId>
             <artifactId>qubership-profiler-test-app</artifactId>
-            <version>2.0.3</version>
+            <version>3.0.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This would resolve CVE issues in profiler's transitive dependencies.

See https://github.com/Netcracker/qubership-profiler-agent/releases/tag/v3.0.0
