### PR TITLE
chore: configure Renovate to automatically bump Profiler versions

### DIFF
--- a/Dockerfile.java-alpine
+++ b/Dockerfile.java-alpine
@@ -80,6 +80,7 @@ RUN mkdir /app && \
     chown -R 10001:0 /app/volumes && \
     find /app \( -type d -exec chmod ug+rwx {} \; -exec chown 10001:0 {} \; -o -type f -exec chmod ug+rw {} \; -exec chown 10001:0 {} \; \)
 
+# renovate: datasource=maven depName=qubership-profiler-installer packageName=org.qubership.profiler versioning=maven
 ARG QUBERSHIP_PROFILER_VERSION=3.0.0
 ARG MAVEN_CENTRAL_URL=https://repo.maven.apache.org/maven2
 # Supported values are: local, remote. Local artifact enables testing the dockerfile without publishing the profiler to Central.

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,26 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "assignAutomerge": true,
   "assigneesFromCodeOwners": true,
-  "reviewersFromCodeOwners": true
+  "reviewersFromCodeOwners": true,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update _VERSION variables in Dockerfiles",
+      "fileMatch": [
+        "(^|/|\\.)Dockerfile$",
+        "(^|/)Dockerfile\\.[^/]*$"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>.+?)(?: (?:packageName|lookupName)=(?<packageName>.+?))?(?: versioning=(?<versioning>[a-z-]+?))?\\s(?:ENV|ARG) .+?_VERSION=(?<currentValue>.+?)\\s"
+      ]
+    }
+  ],
+  "packageRules": [
+    {
+      "groupName": "org.qubership.profiler",
+      "matchPackageNames": [
+        "org.qubership.profiler{/,}**"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
There's v3.0.1 release: https://github.com/Netcracker/qubership-profiler-agent/releases/tag/v3.0.1