### PR TITLE
fix: use a single Docker RUN instruction to reduce the number of layers and the image size

### DIFF
--- a/Dockerfile.java-alpine
+++ b/Dockerfile.java-alpine
@@ -91,9 +91,8 @@ RUN --mount=type=bind,source=local-artifacts,target=/build/artifacts mkdir /app/
     rm "qubership-profiler-installer-$QUBERSHIP_PROFILER_VERSION.zip" && \
     tar -xzf "qubership-profiler-diagtools-$QUBERSHIP_PROFILER_VERSION-$TARGETOS-$TARGETARCH.tar.gz" --strip-components=1 && \
     rm "qubership-profiler-diagtools-$QUBERSHIP_PROFILER_VERSION-$TARGETOS-$TARGETARCH.tar.gz" && \
-    chown -R 10001:0 /app/diag
-
-RUN mkdir /app/diag/dump && \
+    chown -R 10001:0 /app/diag && \
+    mkdir /app/diag/dump && \
     chmod ug+rw -R /app/diag && \
     chown -R 10001:0 /app/diag
 


### PR DESCRIPTION
Currently an extra RUN adds 28 MiB to the image size.

Here's [dive](https://github.com/wagoodman/dive) analysis for ghcr.io/netcracker/qubership-java-base:21-alpine-latest

<img width="1612" height="837" alt="dive analysis for java base image" src="https://github.com/user-attachments/assets/87e2a4d7-58ea-46a6-a061-309695b38b95" />
