### PR TITLE
fix:  logging for signals rethrow

### DIFF
--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -190,7 +190,16 @@ if [[ "$1" != "bash" ]] && [[ "$1" != "sh" ]] ; then
     # shellcheck disable=SC2068
     $@ &
     pid=$!
-    wait "$pid" ; retCode=$?
+
+    while true; do
+        wait "$pid"
+        retCode=$?
+        # continue the waiting if wait was interrupted by a signal.
+        if [[ $retCode -ge 128 ]]; then
+            continue
+        fi
+        break
+    done
     log INFO "Process ended with return code ${retCode}"
 
     # save crash dump for future analysis

--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -194,8 +194,10 @@ if [[ "$1" != "bash" ]] && [[ "$1" != "sh" ]] ; then
     while true; do
         wait "$pid"
         retCode=$?
-        # continue the waiting if wait was interrupted by a signal.
-        if [[ $retCode -ge 128 ]]; then
+        # If wait returned >= 128, either wait was interrupted by a signal or the child
+        # exited with that status (e.g. killed by signal). Only continue when the child
+        # is still running (wait was interrupted); otherwise break with the real exit status.
+        if [[ $retCode -ge 128 ]] && kill -0 "$pid" 2>/dev/null; then
             continue
         fi
         break

--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -110,19 +110,18 @@ run_init_scripts() {
 }
 
 rethrow_handler() {
-    log INFO "Caught $1 sig in entrypoint"
-    #To prevent 503\502 error on rollout new deployment https://rtfm.co.ua/en/kubernetes-nginx-php-fpm-graceful-shutdown-and-502-errors/
-    if [ "$1" == "SIGTERM" ]; then
-      /bin/sleep "${SIGTERM_EXIT_DELAY:-10}"
+    log DEBUG "Caught $1 sig in entrypoint"
+
+    # To prevent 503\502 error on rollout new deployment
+    # https://rtfm.co.ua/en/kubernetes-nginx-php-fpm-graceful-shutdown-and-502-errors/
+    if [ "$1" = "SIGTERM" ]; then
+        sleep "${SIGTERM_EXIT_DELAY:-10}"
     fi
-    local subRetCode=0
-    if [ $pid -ne 0 ]; then
-        log INFO "Rethrow $1 to subprocess: $pid"
+
+    if kill -0 "$pid" 2>/dev/null; then
+        log DEBUG "Rethrow $1 to subprocess: $pid"
         kill -"$1" "$pid"
-        wait "$pid" ; subRetCode=$?
     fi
-    log INFO "Subcommand signaled with $1, exit code $subRetCode"
-    exit $subRetCode
 }
 
 

--- a/tests/signal-propagation/sample-process.sh
+++ b/tests/signal-propagation/sample-process.sh
@@ -4,6 +4,9 @@
 # Exit with 128+SIGUSR1 (158) to simulate being killed by signal
 trap 'echo "Test application: captured SIGUSR1"; exit 158' SIGUSR1
 
+# capure signal but do not exit process (monitoring signal)
+trap 'echo "Test application: captured SIGHUP";' SIGHUP
+
 echo "Waiting for signal"
 while true; do
     sleep 1

--- a/tests/signal-propagation/sample-process.sh
+++ b/tests/signal-propagation/sample-process.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # use SIGUSR1 to avoid sleeping 10 seconds in entrypoint trap handler for SIGTERM
-trap 'echo "Test application: captured SIGUSR1"; exit 0' SIGUSR1
+# Exit with 128+SIGUSR1 (158) to simulate being killed by signal
+trap 'echo "Test application: captured SIGUSR1"; exit 158' SIGUSR1
 
 echo "Waiting for signal"
 while true; do

--- a/tests/signal-propagation/test.sh
+++ b/tests/signal-propagation/test.sh
@@ -8,11 +8,15 @@ CID=$(docker run -d -v "$SCRIPT_DIR:/app/" "$IMAGE" /app/sample-process.sh)
 # wait for sample application process start
 sleep 5
 
-# send test signal
+# signal should be captured by sample application and continue execution
+docker kill --signal=SIGHUP "$CID"
+# signal should be captured by sample application and exit with error code 158
 docker kill --signal=SIGUSR1 "$CID"
 #wait for container exit to make sure that all sample application output is captured
 docker wait "$CID" >/dev/null
-docker logs "$CID" > "$PROC_OUTPUT_FILE"
+docker logs "$CID" >"$PROC_OUTPUT_FILE"
 
 # Test sample application output
-<"$PROC_OUTPUT_FILE" grep "Test application: captured SIGUSR1" >/dev/null
+<"$PROC_OUTPUT_FILE" grep "Test application: captured SIGHUP" >/dev/null || fail "SIGHUP signal not captured"
+<"$PROC_OUTPUT_FILE" grep "Test application: captured SIGUSR1" >/dev/null || fail "SIGUSR1 signal not captured"
+<"$PROC_OUTPUT_FILE" grep "Process ended with return code 158" >/dev/null || fail "Error code didn't propagated correctly"


### PR DESCRIPTION
- rethrow logs were moved to DEBUG mode
- fixed possible race condition on two wait for one pid



<!-- start messages -->
### Commit messages:
[Ksiona](https://github.com/Netcracker/qubership-core-base-images/commit/8bba6ae15f6f4bb0ffee6b6357997a23ab06e724) fix: possible race condintion on two wait for one pid + logging
[Ksiona](https://github.com/Netcracker/qubership-core-base-images/commit/cae4647674773cfac0b4ed7a05d9a36348ca23e5) fix: tests for signal rethrow
[lis0x90](https://github.com/Netcracker/qubership-core-base-images/commit/ecfb4810973c27b903112ffe7222f5df83dde72b) chore: test correct non zero exit code handling in entrypoint wait loop
[lis0x90](https://github.com/Netcracker/qubership-core-base-images/commit/cf2d8dfd88a14dbf1f3700c999475ca56b45d09f) chore: fix entrypoint.sh and add test cases
<!-- end messages -->



