### PR TITLE
bugfix: restore BWC, set NC_DIAGNOSTIC_MODE=off as default value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /.idea
 /local-artifacts
 !/local-artifacts/README.md
+/.vscode
+/.metals

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.compile.nullAnalysis.mode": "automatic"
-}

--- a/images/core/Dockerfile
+++ b/images/core/Dockerfile
@@ -13,7 +13,8 @@ ENV HOME=/app \
     CERTIFICATE_FILE_LOCATION=/usr/local/share/ca-certificates \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US:en \
-    LC_ALL=en_US.UTF-8
+    LC_ALL=en_US.UTF-8 \
+    NC_DIAGNOSTIC_MODE=off
 
 RUN adduser -u ${UID} -G ${GID} -S appuser
 

--- a/images/core/Dockerfile
+++ b/images/core/Dockerfile
@@ -13,8 +13,7 @@ ENV HOME=/app \
     CERTIFICATE_FILE_LOCATION=/usr/local/share/ca-certificates \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US:en \
-    LC_ALL=en_US.UTF-8 \
-    NC_DIAGNOSTIC_MODE=off
+    LC_ALL=en_US.UTF-8
 
 RUN adduser -u ${UID} -G ${GID} -S appuser
 

--- a/images/java-21-prof/Dockerfile
+++ b/images/java-21-prof/Dockerfile
@@ -26,7 +26,9 @@ ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk \
     MALLOC_TRIM_THRESHOLD_=131072 \
     MALLOC_TOP_PAD_=131072 \
     MALLOC_MMAP_MAX=65536 \
-    JAVA_CERTIFICATE_FILE_LOCATION=/etc/ssl/certs/java/cacerts
+    JAVA_CERTIFICATE_FILE_LOCATION=/etc/ssl/certs/java/cacerts \
+    NC_DIAGNOSTIC_MODE=off \
+    NC_DIAGNOSTIC_FOLDER=/app/ncdiag
 
 RUN mkdir -p /tmp/cert && \
     chmod -R ug+rw /tmp && \

--- a/images/java-21-prof/Dockerfile
+++ b/images/java-21-prof/Dockerfile
@@ -27,8 +27,7 @@ ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk \
     MALLOC_TOP_PAD_=131072 \
     MALLOC_MMAP_MAX=65536 \
     JAVA_CERTIFICATE_FILE_LOCATION=/etc/ssl/certs/java/cacerts \
-    NC_DIAGNOSTIC_MODE=off \
-    NC_DIAGNOSTIC_FOLDER=/app/ncdiag
+    NC_DIAGNOSTIC_MODE=off
 
 RUN mkdir -p /tmp/cert && \
     chmod -R ug+rw /tmp && \

--- a/images/java-25-prof/Dockerfile
+++ b/images/java-25-prof/Dockerfile
@@ -12,6 +12,9 @@ USER root
 
 RUN echo $BASE_IMAGE_TAG > /etc/base-image-release
 
+ENV NC_DIAGNOSTIC_MODE=off \
+    NC_DIAGNOSTIC_FOLDER=/app/ncdiag
+
 # renovate: datasource=maven depName=qubership-profiler-installer packageName=org.qubership.profiler:qubership-profiler-installer versioning=maven
 ARG QUBERSHIP_PROFILER_VERSION=3.1.3
 ARG MAVEN_CENTRAL_URL=https://repo.maven.apache.org/maven2

--- a/images/java-25-prof/Dockerfile
+++ b/images/java-25-prof/Dockerfile
@@ -12,8 +12,7 @@ USER root
 
 RUN echo $BASE_IMAGE_TAG > /etc/base-image-release
 
-ENV NC_DIAGNOSTIC_MODE=off \
-    NC_DIAGNOSTIC_FOLDER=/app/ncdiag
+ENV NC_DIAGNOSTIC_MODE=off
 
 # renovate: datasource=maven depName=qubership-profiler-installer packageName=org.qubership.profiler:qubership-profiler-installer versioning=maven
 ARG QUBERSHIP_PROFILER_VERSION=3.1.3

--- a/test-profiler/src/test/java/com/netcracker/core/test/JavaBaseImageTest.java
+++ b/test-profiler/src/test/java/com/netcracker/core/test/JavaBaseImageTest.java
@@ -37,7 +37,8 @@ public class JavaBaseImageTest {
                      new MockCollectorServer(0, ProtocolConst.PLAIN_SOCKET_BACKLOG)
                              .started(Duration.ofSeconds(5));
              GenericContainer<?> profilerApp = new GenericContainer<>(CORE_BASE_IMAGE_TAG)
-                     .withEnv("NC_DIAGNOSTIC_MODE", "prod")
+                     // test variable effect
+                     //.withEnv("NC_DIAGNOSTIC_MODE", "prod")
                      .withEnv("ESC_LOG_LEVEL", "debug")
                      .withEnv("PROFILER_ENABLED", "true")
                      .withEnv("REMOTE_DUMP_HOST", "host.testcontainers.internal")

--- a/test-profiler/src/test/java/com/netcracker/core/test/JavaBaseImageTest.java
+++ b/test-profiler/src/test/java/com/netcracker/core/test/JavaBaseImageTest.java
@@ -37,8 +37,7 @@ public class JavaBaseImageTest {
                      new MockCollectorServer(0, ProtocolConst.PLAIN_SOCKET_BACKLOG)
                              .started(Duration.ofSeconds(5));
              GenericContainer<?> profilerApp = new GenericContainer<>(CORE_BASE_IMAGE_TAG)
-                     // test variable effect
-                     //.withEnv("NC_DIAGNOSTIC_MODE", "prod")
+                     .withEnv("NC_DIAGNOSTIC_MODE", "prod")
                      .withEnv("ESC_LOG_LEVEL", "debug")
                      .withEnv("PROFILER_ENABLED", "true")
                      .withEnv("REMOTE_DUMP_HOST", "host.testcontainers.internal")

--- a/test-profiler/src/test/java/com/netcracker/core/test/JavaBaseImageTest.java
+++ b/test-profiler/src/test/java/com/netcracker/core/test/JavaBaseImageTest.java
@@ -37,7 +37,7 @@ public class JavaBaseImageTest {
                      new MockCollectorServer(0, ProtocolConst.PLAIN_SOCKET_BACKLOG)
                              .started(Duration.ofSeconds(5));
              GenericContainer<?> profilerApp = new GenericContainer<>(CORE_BASE_IMAGE_TAG)
-                     .withEnv("NC_DIAGNOSTIC_MODE", "dev")
+                     .withEnv("NC_DIAGNOSTIC_MODE", "prod")
                      .withEnv("ESC_LOG_LEVEL", "debug")
                      .withEnv("PROFILER_ENABLED", "true")
                      .withEnv("REMOTE_DUMP_HOST", "host.testcontainers.internal")

--- a/test-profiler/src/test/java/com/netcracker/core/test/JavaBaseImageTest.java
+++ b/test-profiler/src/test/java/com/netcracker/core/test/JavaBaseImageTest.java
@@ -37,6 +37,7 @@ public class JavaBaseImageTest {
                      new MockCollectorServer(0, ProtocolConst.PLAIN_SOCKET_BACKLOG)
                              .started(Duration.ofSeconds(5));
              GenericContainer<?> profilerApp = new GenericContainer<>(CORE_BASE_IMAGE_TAG)
+                     .withEnv("NC_DIAGNOSTIC_MODE", "dev")
                      .withEnv("ESC_LOG_LEVEL", "debug")
                      .withEnv("PROFILER_ENABLED", "true")
                      .withEnv("REMOTE_DUMP_HOST", "host.testcontainers.internal")


### PR DESCRIPTION
Restore backward compatibility to parent base images where `NC_DIAGNOSTIC_MODE` was set to `off` value by default 







<!-- start messages -->
### Commit messages:
[lis0x90](https://github.com/Netcracker/qubership-core-base-images/commit/c908a229d05518f4750046fd6c96c5fe024807e0) bugfix: restore BWC: set NC_DIAGNOSTIC_MODE=off as default value
[lis0x90](https://github.com/Netcracker/qubership-core-base-images/commit/66d6bf9eb68098ced2c9c7dccd48d672f04d0210) bugfix: set NC_DIAGNOSTIC_MODE=off as default value
[lis0x90](https://github.com/Netcracker/qubership-core-base-images/commit/3df1e2ca173c3de0b0c549cf673c7ea8779a8fdf) bugfix: fix profiler test
[lis0x90](https://github.com/Netcracker/qubership-core-base-images/commit/de0f37f9fcf3ae9371c7d36ad2e1d57b50eacbb4) bugfix: fix profiler test
[lis0x90](https://github.com/Netcracker/qubership-core-base-images/commit/3d504e087bf4e837118bd2736c887df28dae9c67) bugfix: fix profiler test
[lis0x90](https://github.com/Netcracker/qubership-core-base-images/commit/dcd030e0438ca33f750e82bf960d49406ae14da8) bugfix: fix profiler test
[lis0x90](https://github.com/Netcracker/qubership-core-base-images/commit/0fc70133456cc1a2db7115f05b21a26e81ca8934) bugfix: fix profiler test
[lis0x90](https://github.com/Netcracker/qubership-core-base-images/commit/bee73bc0a3b40d6c8bbd89d14b41d3c5067278a6) bugfix: fix profiler test
<!-- end messages -->







