### PR TITLE
fix: handle spaces in entrypoint

### DIFF
--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -201,7 +201,7 @@ if [[ "$1" != "bash" ]] && [[ "$1" != "sh" ]] ; then
 else
     # shellcheck disable=SC2068
     log INFO "Run subcommand:" "$@"
-    exec $@
+    exec "$@"
 fi
 
 


### PR DESCRIPTION
While executing with gitlab ci , 
Unquoted $@ can split arguments incorrectly when they contain spaces or special characters
Quoted "$@" preserves each argument as a separate word.