### PR TITLE
fix: Java CA trust store on OpenShift / random UID when update-ca-certificates fails

### DIFF
--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -51,7 +51,15 @@ load_certificates() {
         filename { print > filename }
         END { if (!found) exit 1 }" || log ERROR "Error process certificates file ${cert}: invalid certificates file data format. " >&2
     done
-    update-ca-certificates > /dev/null 2>&1 || log ERROR "Error updating CA certificates store" >&2
+
+    # update certificates plugin for java will fail in case of non-standard file permissions and running user id
+    # but we can do workaround by extracting certificates from trust store and copying them to java keystore (openshift case)
+    if ! update-ca-certificates > /dev/null 2>&1; then
+      log WARN "Error updating CA certificates store. Try alternative method to update certificates for java keystore." >&2
+      trust extract --overwrite --format=java-cacerts --filter=ca-anchors --purpose server-auth /tmp/cacerts.tmp || log ERROR "Error extracting certificates for java keystore" >&2
+      cp -f /tmp/cacerts.tmp /etc/ssl/certs/java/cacerts || log ERROR "Error copying certificates to java keystore" >&2
+    fi
+
     log INFO "Done"
 
     if [[ -x /usr/bin/keytool ]]; then

--- a/images/java-21-prof/Dockerfile
+++ b/images/java-21-prof/Dockerfile
@@ -93,5 +93,7 @@ RUN echo $BASE_IMAGE_TAG > /etc/base-image-release
 
 COPY images/java-21-prof/font-local.conf /etc/fonts/local.conf
 
+VOLUME /etc/ssl/certs/java/
+
 USER ${UID}:${GID}
 

--- a/tests/certificates/test.sh
+++ b/tests/certificates/test.sh
@@ -4,13 +4,14 @@ set -ex
 CERTS_DIR="$SCRIPT_DIR/certs"
 
 export_image_trust_store() {
-  local output_file=$1
-  local fs_mode=${2:-rw}
+  local output_file=${1:?Missed mandatory parameter: output file}
+  local fs_mode=${2:?Missed mandatory parameter: fs mode}
+  shift 2
   echo "Export certificate list from: $IMAGE, FS mode: ${fs_mode}"
   # shellcheck disable=SC2046
-  docker run --rm \
+  docker run "${@}" --rm \
       -v "${CERTS_DIR}":/tmp/cert/ \
-      $(read_only_params $fs_mode) \
+      $(read_only_params "$fs_mode") \
       "$IMAGE" \
       cat /etc/ssl/certs/ca-certificates.crt >"${output_file}.crt"
 
@@ -19,16 +20,17 @@ export_image_trust_store() {
 }
 
 export_java_keystore() {
-  local output_file=$1
-  local fs_mode=${2:-rw}
+  local output_file=${1:?Missed mandatory parameter: output file}
+  local fs_mode=${2:?Missed mandatory parameter: fs mode}
+  shift 2
   echo "Export certificate list from: $IMAGE, FS mode: ${fs_mode}"
   # shellcheck disable=SC2046
-  docker run --rm \
+  docker run "${@}" --rm \
       -v "${CERTS_DIR}":/tmp/cert/ \
       -e CERTIFICATE_FILE_PASSWORD=abc12345 \
-      $(read_only_params $fs_mode) \
+      $(read_only_params "$fs_mode") \
       "$IMAGE" \
-      keytool -list -cacerts -storepass abc12345 -v >${output_file}
+      keytool -list -cacerts -storepass abc12345 -v >"${output_file}"
 }
 
 assert_tests() {
@@ -40,18 +42,29 @@ assert_tests() {
 }
 
 EXPORTED_CERTS_FILE=$(mktemp /tmp/certificates-test.XXXXXX)
-export_image_trust_store "$EXPORTED_CERTS_FILE"
+export_image_trust_store "$EXPORTED_CERTS_FILE" rw
 assert_tests "$EXPORTED_CERTS_FILE"
 
 # Test the same with volume mounted to cert path directory in read-only mode
 export_image_trust_store "$EXPORTED_CERTS_FILE" ro
 assert_tests "$EXPORTED_CERTS_FILE"
 
+# OpenShift case with random UID
+export_image_trust_store "$EXPORTED_CERTS_FILE" ro -u 10009000
+assert_tests "$EXPORTED_CERTS_FILE"
+
 if [[ "$IMAGE" == *java* ]]; then
   echo "Test certificates imported in JKS"
-  export_java_keystore "$EXPORTED_CERTS_FILE"
+  export_java_keystore "$EXPORTED_CERTS_FILE" rw
   assert_tests "$EXPORTED_CERTS_FILE"
 
   export_java_keystore "$EXPORTED_CERTS_FILE" ro
+  assert_tests "$EXPORTED_CERTS_FILE"
+
+  # OpenShift case with random UID
+  export_java_keystore "$EXPORTED_CERTS_FILE" rw -u 10009000
+  assert_tests "$EXPORTED_CERTS_FILE"
+
+  export_java_keystore "$EXPORTED_CERTS_FILE" ro -u 10009000
   assert_tests "$EXPORTED_CERTS_FILE"
 fi

--- a/tests/test-suite.sh
+++ b/tests/test-suite.sh
@@ -73,17 +73,11 @@ run_test() {
     fi
 }
 
-run_test version-log
-run_test log-format
-run_test certificates
-run_test nss
-run_test args-passing
-run_test tls
-run_test send-crash-dump
-run_test signal-propagation
-run_test bash-entrypoint-arguments
-run_test nginx-lua
-run_test nginx-brotli
-run_test nginx-otel
+# optional: glob pattern to filter test folders (default: all)
+TEST_FILTER=${2:-*}
+find "$SUITE_DIR" -maxdepth 1 -mindepth 1 -name "$TEST_FILTER" -type d -printf "%f\n" | while read -r test_name; do
+  run_test "$test_name"
+done
+
 
 echo -e "${GREEN_COLOR}All tests passed${RESET_COLOR}"


### PR DESCRIPTION
# Problem
load_certificates in the shared entrypoint merges PEMs from /tmp/cert and the Kubernetes service account directory, then refreshes trust. For Java images, the JVM relies on /etc/ssl/certs/java/cacerts. If update-ca-certificates fails (permissions, layout, or environment quirks), the Java trust store could stay wrong or stale.

# Solution
When update-ca-certificates fails, the entrypoint falls back to:
* trust extract --overwrite --format=java-cacerts --filter=ca-anchors --purpose server-auth into a temp file
* copy that result to /etc/ssl/certs/java/cacerts