### PR TITLE
chore: remove curl from image due to endless CVE reports

### DIFF
--- a/images/core/Dockerfile
+++ b/images/core/Dockerfile
@@ -6,7 +6,7 @@ ARG UID=10001
 ARG GID=root
 
 RUN apk update --no-cache
-RUN apk add --no-cache ca-certificates curl bash nss_wrapper
+RUN apk add --no-cache ca-certificates bash nss_wrapper
 
 ENV HOME=/app \
     USER_NAME=appuser \


### PR DESCRIPTION
Remove `curl` package from `core` image due endless stream of CVE reports. 
As a replacement there is `wget` tool from busybox package 