### PR TITLE
fix: handle BusyBox cp -Rn bug in restore_volumes_data

### DIFF
--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -93,7 +93,16 @@ create_user() {
 }
 
 restore_volumes_data() {
-    [ -d /app/volumes/certs ] && cp -Rn /app/volumes/certs/. /etc/ssl/certs
+    if [ -d /app/volumes/certs ]; then
+        # BusyBox cp -Rn silently copies nothing on Alpine 3.23+, so we
+        # check whether the target is empty first and fall back to cp -R.
+        if [ -z "$(ls -A /etc/ssl/certs 2>/dev/null)" ]; then
+            cp -R /app/volumes/certs/. /etc/ssl/certs
+        else
+            cp -Rn /app/volumes/certs/. /etc/ssl/certs 2>/dev/null || \
+                cp -R /app/volumes/certs/. /etc/ssl/certs
+        fi
+    fi
 }
 
 run_init_scripts() {

--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -94,14 +94,10 @@ create_user() {
 
 restore_volumes_data() {
     if [ -d /app/volumes/certs ]; then
-        # BusyBox cp -Rn silently copies nothing on Alpine 3.23+, so we
-        # check whether the target is empty first and fall back to cp -R.
-        if [ -z "$(ls -A /etc/ssl/certs 2>/dev/null)" ]; then
-            cp -R /app/volumes/certs/. /etc/ssl/certs
-        else
-            cp -Rn /app/volumes/certs/. /etc/ssl/certs 2>/dev/null || \
-                cp -R /app/volumes/certs/. /etc/ssl/certs
-        fi
+        # Avoid the "src/." idiom — BusyBox cp -Rn treats "." as the last
+        # path component, sees dest/. already exists, and skips the copy.
+        # Glob expansion sidesteps the issue while keeping -n semantics.
+        cp -Rn /app/volumes/certs/* /app/volumes/certs/.[!.]* /etc/ssl/certs/ 2>/dev/null || true
     fi
 }
 

--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -57,6 +57,7 @@ load_certificates() {
     if ! update-ca-certificates > /dev/null 2>&1; then
       log WARN "Error updating CA certificates store. Try alternative method to update certificates for java keystore." >&2
       trust extract --overwrite --format=java-cacerts --filter=ca-anchors --purpose server-auth /tmp/cacerts.tmp || log ERROR "Error extracting certificates for java keystore" >&2
+      mkdir -p /etc/ssl/certs/java
       cp -f /tmp/cacerts.tmp /etc/ssl/certs/java/cacerts || log ERROR "Error copying certificates to java keystore" >&2
     fi
 
@@ -147,9 +148,9 @@ if [ -f /app/diag/diag-bootstrap.sh ]; then
 fi
 
 log INFO "Run entrypoint.sh:"
-restore_volumes_data
+restore_volumes_data # - тут наша бага - скопировано 0 файлов. никто не замечал
 create_user
-load_certificates
+load_certificates # потому что здесь происходит копирование реально полезных сертов
 
 # See full current list in http://man7.org/linux/man-pages/man7/signal.7.html
 export SIGNALS_TO_RETHROW="

--- a/tests/certificates/test.sh
+++ b/tests/certificates/test.sh
@@ -19,6 +19,22 @@ export_image_trust_store() {
   openssl crl2pkcs7 -nocrl -certfile "${output_file}.crt" | openssl pkcs7 -print_certs -noout >"${output_file}"
 }
 
+export_image_trust_store_with_emptydir() {
+  local output_file=${1:?Missed mandatory parameter: output file}
+  shift
+  echo "Export certificate list from: $IMAGE, emptyDir at /etc/ssl/certs (restore_volumes_data test)"
+  # --tmpfs /etc/ssl/certs simulates a Kubernetes emptyDir mount over the VOLUME-declared path,
+  # wiping all baked-in certs. restore_volumes_data() must restore them from /app/volumes/certs/.
+  # Without the fix, BusyBox cp -Rn /app/volumes/certs/. /etc/ssl/certs silently skipped all files.
+  docker run "${@}" --rm \
+      -v "${CERTS_DIR}":/tmp/cert/ \
+      --tmpfs /etc/ssl/certs \
+      "$IMAGE" \
+      cat /etc/ssl/certs/ca-certificates.crt >"${output_file}.crt"
+
+  openssl crl2pkcs7 -nocrl -certfile "${output_file}.crt" | openssl pkcs7 -print_certs -noout >"${output_file}"
+}
+
 export_java_keystore() {
   local output_file=${1:?Missed mandatory parameter: output file}
   local fs_mode=${2:?Missed mandatory parameter: fs mode}
@@ -51,6 +67,17 @@ assert_tests "$EXPORTED_CERTS_FILE"
 
 # OpenShift case with random UID
 export_image_trust_store "$EXPORTED_CERTS_FILE" ro -u 10009000
+assert_tests "$EXPORTED_CERTS_FILE"
+
+# Test restore_volumes_data: simulate Kubernetes emptyDir mount over /etc/ssl/certs.
+# This is the exact scenario where the BusyBox cp -Rn /. bug was triggered — the src/.
+# idiom caused cp to silently skip all files when the destination already existed.
+echo "Test restore_volumes_data with emptyDir at /etc/ssl/certs (BusyBox cp -Rn fix)"
+export_image_trust_store_with_emptydir "$EXPORTED_CERTS_FILE"
+assert_tests "$EXPORTED_CERTS_FILE"
+
+# OpenShift case with random UID
+export_image_trust_store_with_emptydir "$EXPORTED_CERTS_FILE" -u 10009000
 assert_tests "$EXPORTED_CERTS_FILE"
 
 if [[ "$IMAGE" == *java* ]]; then

--- a/tests/certificates/test.sh
+++ b/tests/certificates/test.sh
@@ -33,6 +33,32 @@ test_restore_volumes_data() {
   [ "${count:-0}" -gt 0 ] || fail "restore_volumes_data restored 0 files from /app/volumes/certs"
 }
 
+test_load_certificates_java_keystore_fallback() {
+  echo "Test: load_certificates fallback creates java/cacerts when java/ subdir is absent (Kubernetes emptyDir)"
+  # Kubernetes mounts /etc/ssl/certs as emptyDir, so the java/ subdir does not pre-exist.
+  # When update-ca-certificates fails (e.g. OpenShift SCC), the fallback must mkdir -p first,
+  # otherwise BusyBox cp cannot create java/cacerts and keytool fails with "Not a directory".
+  #
+  # We cannot directly simulate "java/ missing" in local Docker/Podman because both
+  # /etc/ssl/certs and /etc/ssl/certs/java are declared as separate VOLUMEs in the image, so
+  # the nested java/ volume is always mounted even with --tmpfs /etc/ssl/certs.
+  # Instead, we extract load_certificates from each image via awk and redirect the java/
+  # path to /tmp/testjava (a fresh dir with no java/ subdir pre-created), then verify
+  # whether the function creates /tmp/testjava/cacerts.
+  local result
+  result=$(docker run --rm --entrypoint=bash "${@}" "$IMAGE" \
+    -c '
+      log() { true; }
+      eval "$(awk "/^load_certificates\(\)/,/^\}$/ {print; if (/^\}$/) exit}" /usr/bin/entrypoint.sh \
+            | sed "s|/etc/ssl/certs/java|/tmp/testjava|g")"
+      update-ca-certificates() { return 1; }
+      load_certificates 2>/dev/null
+      [ -f /tmp/testjava/cacerts ] && echo "PASS" || echo "FAIL"
+    ')
+  result="${result//[[:space:]]/}"
+  [ "$result" = "PASS" ] || fail "load_certificates fallback did not create java/cacerts: got '$result'"
+}
+
 export_image_trust_store_with_emptydir() {
   local output_file=${1:?Missed mandatory parameter: output file}
   shift
@@ -106,4 +132,7 @@ if [[ "$IMAGE" == *java* ]]; then
 
   export_java_keystore "$EXPORTED_CERTS_FILE" ro -u 10009000
   assert_tests "$EXPORTED_CERTS_FILE"
+
+  # Unit test: fallback path in load_certificates creates java/cacerts when java/ subdir is absent.
+  test_load_certificates_java_keystore_fallback
 fi

--- a/tests/certificates/test.sh
+++ b/tests/certificates/test.sh
@@ -19,13 +19,24 @@ export_image_trust_store() {
   openssl crl2pkcs7 -nocrl -certfile "${output_file}.crt" | openssl pkcs7 -print_certs -noout >"${output_file}"
 }
 
+test_restore_volumes_data() {
+  echo "Test: restore_volumes_data restores certs from backup when /etc/ssl/certs is empty (emptyDir)"
+  local count
+  count=$(docker run --rm --entrypoint=bash "${@}" "$IMAGE" \
+    -c '
+      rm -rf /etc/ssl/certs/* /etc/ssl/certs/java 2>/dev/null || true
+      eval "$(awk "/^restore_volumes_data\(\)/,/^\}$/ {print; if (/^\}$/) exit}" /usr/bin/entrypoint.sh)"
+      restore_volumes_data
+      find /etc/ssl/certs -type f 2>/dev/null | wc -l
+    ')
+  count="${count//[[:space:]]/}"
+  [ "${count:-0}" -gt 0 ] || fail "restore_volumes_data restored 0 files from /app/volumes/certs"
+}
+
 export_image_trust_store_with_emptydir() {
   local output_file=${1:?Missed mandatory parameter: output file}
   shift
-  echo "Export certificate list from: $IMAGE, emptyDir at /etc/ssl/certs (restore_volumes_data test)"
-  # --tmpfs /etc/ssl/certs simulates a Kubernetes emptyDir mount over the VOLUME-declared path,
-  # wiping all baked-in certs. restore_volumes_data() must restore them from /app/volumes/certs/.
-  # Without the fix, BusyBox cp -Rn /app/volumes/certs/. /etc/ssl/certs silently skipped all files.
+  echo "Export certificate list from: $IMAGE, emptyDir at /etc/ssl/certs"
   docker run "${@}" --rm \
       -v "${CERTS_DIR}":/tmp/cert/ \
       --tmpfs /etc/ssl/certs \
@@ -69,10 +80,11 @@ assert_tests "$EXPORTED_CERTS_FILE"
 export_image_trust_store "$EXPORTED_CERTS_FILE" ro -u 10009000
 assert_tests "$EXPORTED_CERTS_FILE"
 
-# Test restore_volumes_data: simulate Kubernetes emptyDir mount over /etc/ssl/certs.
-# This is the exact scenario where the BusyBox cp -Rn /. bug was triggered — the src/.
-# idiom caused cp to silently skip all files when the destination already existed.
-echo "Test restore_volumes_data with emptyDir at /etc/ssl/certs (BusyBox cp -Rn fix)"
+# Unit test: restore_volumes_data in isolation before update-ca-certificates runs.
+test_restore_volumes_data
+test_restore_volumes_data -u 10009000
+
+# Integration test: full entrypoint flow with emptyDir over /etc/ssl/certs.
 export_image_trust_store_with_emptydir "$EXPORTED_CERTS_FILE"
 assert_tests "$EXPORTED_CERTS_FILE"
 


### PR DESCRIPTION
Fixes #175

### What

`restore_volumes_data()` uses `cp -Rn /app/volumes/certs/. /etc/ssl/certs` to restore backed-up certificates at container startup. This handles the case where `/etc/ssl/certs` is replaced by a Kubernetes emptyDir (because the Dockerfile declares it as a `VOLUME`).

The problem is BusyBox-specific and only affects the `src/.` idiom: BusyBox computes the destination by appending the last path component of the source, which for `src/.` is `.` — so the destination becomes `dest/.`. That already exists (it's the directory itself), and with `-n` set, `copy_file()` returns immediately without recursing. Nothing gets copied.

This isn't a blanket `cp -Rn` bug. `cp -Rn src dest` and `cp -Rn src/ dest/` work fine. It's the `/.` form specifically.

### Fix

Replace the `src/.` idiom with glob expansion (`*` + `.[!.]*`), which covers all entries including dot-prefixed ones (minus `.` and `..`) and avoids the BusyBox path component issue:

```bash
cp -Rn /app/volumes/certs/* /app/volumes/certs/.[!.]* /etc/ssl/certs/ 2>/dev/null || true
```

The `|| true` handles the case where `.[!.]*` matches nothing (no dotfiles in the backup dir) — without it the glob would expand literally and `cp` would error out.

### Tested

Verified in a running OpenShift pod (qubership-java-base:21-alpine-2.2.1, Alpine 3.23.3, BusyBox 1.37.0):

```
# Old command — 0 files copied
cp -Rn /app/volumes/certs/. /etc/ssl/certs

# New command — 298 files copied, including java/cacerts with 148 CAs
cp -Rn /app/volumes/certs/* /app/volumes/certs/.[!.]* /etc/ssl/certs/
keytool -list -cacerts -storepass changeit | grep -c "trustedCertEntry"
# 148
```