### PR TITLE
fix: update docs and fallback for trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,8 @@ If you need to run a container in a read-only host environment, you must mount t
 * `/etc/env` - to manage environment configurations
 * `/app/nss` - to manage NSS (Network Security Services) data
 * `/app/ncdiag` - to store diagnostic and troubleshooting data
-* `/etc/ssl/certs/java` - to handle Java SSL certificates (declared as a volume in profiler images), or `/etc/ssl/certs` for non-Java images
+* `/etc/ssl/certs/java` - to handle Java SSL certificates (declared as a volume in profiler images)
+* `/etc/ssl/certs` - to handle SSL certificates for all images (including both Java and non-Java images)
 * `/var/log` and `/var/cache/nginx/*` - for NGINX image (logs and cache directories)
 
 

--- a/images/core/Dockerfile
+++ b/images/core/Dockerfile
@@ -6,7 +6,7 @@ ARG UID=10001
 ARG GID=root
 
 RUN apk update --no-cache  && apk upgrade
-RUN apk add --no-cache ca-certificates bash nss_wrapper
+RUN apk add --no-cache ca-certificates bash p11-kit nss_wrapper
 RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main curl
 
 ENV HOME=/app \

--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -58,19 +58,18 @@ load_certificates() {
     # but we can do workaround by extracting certificates from trust store and copying them to java keystore (openshift case)
     log DEBUG "Running update-ca-certificates"
 
+    _uca_ok=0
     if [[ "${LOG_LEVEL_EFFECTIVE^^}" == "DEBUG" ]]; then
-      update-ca-certificates -v || log WARN "Error updating CA certificates store. Try alternative method to update certificates for java keystore. " >&2
+      update-ca-certificates -v || _uca_ok=1
     else
-      update-ca-certificates >/dev/null 2>&1 || log WARN "Error updating CA certificates store. Try alternative method to update certificates for java keystore. For details, run with IMAGE_LOG_LEVEL=DEBUG." >&2
+      update-ca-certificates >/dev/null 2>&1 || _uca_ok=1
     fi
 
-    # Refresh Java cacerts from the trust store after system CA update (replaces Alpine's java-cacerts hook).
-    _ks=${JAVA_CERTIFICATE_FILE_LOCATION:-/etc/ssl/certs/java/cacerts}
-    chmod g+rw "$(dirname "${_ks}")" "${_ks}" 2>/dev/null || true
-    if trust extract --overwrite --format=java-cacerts --filter=ca-anchors --purpose server-auth "${_ks}"; then
-      log DEBUG "trust extract: refreshed Java keystore at ${_ks}"
-    else
-      log WARN "trust extract failed for ${_ks}; trying /tmp then copy" >&2
+    if [[ "${_uca_ok}" -ne 0 ]]; then
+      log WARN "Error updating CA certificates store. Try alternative method to update certificates for java keystore. For details, run with IMAGE_LOG_LEVEL=DEBUG." >&2
+
+      # Fallback: rebuild Java cacerts from the system trust store (OpenShift / random UID cases).
+      _ks=${JAVA_CERTIFICATE_FILE_LOCATION:-/etc/ssl/certs/java/cacerts}
       trust extract --overwrite --format=java-cacerts --filter=ca-anchors --purpose server-auth /tmp/cacerts.tmp || log ERROR "Error extracting certificates for java keystore" >&2
       cp -f /tmp/cacerts.tmp "${_ks}" || log ERROR "Error copying certificates to java keystore" >&2
     fi


### PR DESCRIPTION
Some follow-up for cert fix in MR 180.

* update README about importance of mounting `/etc/ssl/certs` in read-only file system
* update core Dockerfile to install `p11-kit` package (for `trust` utility) - otherwise we see (`trust: command not found`) in logs
* update `entrypoint.sh` to use `trust` only as fallback in case `update-ca-certificates` returns non-zero code

See also https://github.com/Netcracker/qubership-core-base-images/pull/180
<!-- start messages -->
### Commit messages:
[radiantgeek](https://github.com/Netcracker/qubership-core-base-images/commit/b814a9c603d27604781b440e706ed57856938388) fix: update docs and fallback for trust
<!-- end messages -->
