### PR TITLE
feat: Migrate to Amazon Corretto

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,14 @@ FROM ghcr.io/netcracker/qubership-nginx-base:latest
 ### Java 21 Image
 
 - **Base Image**: `alpine:3.23.3` (via core base image)
-- **Java Version**: OpenJDK 21 (JDK)
+- **Java Version**: Amazon Corretto 21 (JDK)
 - **Default User**: `appuser` (UID: 10001)
 - **Default Home**: `/app`
 - **Default Language**: `en_US.UTF-8`
 
 #### Additional Dependencies
 
-- `openjdk21-jdk`: Latest version
+- `amazon-corretto-21`: Latest version
 - `fontconfig`: Latest version
 - `font-dejavu`: Latest version
 - `procps-ng`: Latest version
@@ -113,7 +113,7 @@ FROM ghcr.io/netcracker/qubership-nginx-base:latest
 
 #### Java 21 Environment Variables
 
-- `JAVA_HOME`: `/usr/lib/jvm/java-21-openjdk`
+- `JAVA_HOME`: `/usr/lib/jvm/java-21-amazon-corretto`
 - `MALLOC_ARENA_MAX`: 2
 - `MALLOC_MMAP_THRESHOLD_`: 131072
 - `MALLOC_TRIM_THRESHOLD_`: 131072
@@ -123,14 +123,14 @@ FROM ghcr.io/netcracker/qubership-nginx-base:latest
 ### Java 25 Images
 
 - **Base Image**: `alpine:3.23.3` (via core base image)
-- **Java Version**: OpenJDK 25 (JRE)
+- **Java Version**: Amazon Corretto 25 (JDK)
 - **Default User**: `appuser` (UID: 10001)
 - **Default Home**: `/app`
 - **Default Language**: `en_US.UTF-8`
 
 #### Additional Dependencies
 
-- `openjdk25-jre-headless`: Latest version
+- `amazon-corretto-25`: Latest version
 - `curl`: Latest version
 - `bash`: Latest version
 - `nss_wrapper`: Latest version
@@ -138,7 +138,7 @@ FROM ghcr.io/netcracker/qubership-nginx-base:latest
 
 #### Java 25 Environment Variables
 
-- `JAVA_HOME`: `/usr/lib/jvm/default-jvm`
+- `JAVA_HOME`: `/usr/lib/jvm/java-25-amazon-corretto`
 - `MALLOC_ARENA_MAX`: 2
 - `MALLOC_MMAP_THRESHOLD_`: 131072
 - `MALLOC_TRIM_THRESHOLD_`: 131072

--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -18,16 +18,17 @@ SCRIPT_PATH="${BASH_SOURCE[0]}"
 SCRIPT_NAME="$(basename "$SCRIPT_PATH")"
 
 log() {
+  { local -; set +x; } 2>/dev/null
   local severity severity_number _timestamp
   severity=${1^^:-INFO}
   shift
   severity_number=$(severity_to_number "$severity")
 
-    if [ "$severity_number" -ge "$CURRENT_LOG_LEVEL" ]; then
-      _timestamp=$(date +%Y-%m-%dT%H:%M:%S$(printf ".%03d" $(date +%N | cut -c1-3)))
+  if [ "$severity_number" -ge "$CURRENT_LOG_LEVEL" ]; then
+    _timestamp=$(date +%Y-%m-%dT%H:%M:%S$(printf ".%03d" $(date +%N | cut -c1-3)))
 
-       printf '[%s] [%s] [request_id=-] [tenant_id=-] [thread=-] [class=-] [%s] %s\n' "${_timestamp}" "${severity}" "${SCRIPT_NAME}" "$*" >&2
-    fi
+     printf '[%s] [%s] [request_id=-] [tenant_id=-] [thread=-] [class=-] [%s] %s\n' "${_timestamp}" "${severity}" "${SCRIPT_NAME}" "$*" >&2
+  fi
 }
 
 export -f log
@@ -65,28 +66,24 @@ load_certificates() {
     fi
 
     # Refresh Java cacerts from the trust store after system CA update (replaces Alpine's java-cacerts hook).
-    _ks=${JAVA_CERTIFICATE_FILE_LOCATION:-/etc/ssl/certs/java/cacerts}
-    chmod g+rw "$(dirname "${_ks}")" "${_ks}" 2>/dev/null || true
-    if trust extract --overwrite --format=java-cacerts --filter=ca-anchors --purpose server-auth "${_ks}"; then
-      log DEBUG "trust extract: refreshed Java keystore at ${_ks}"
-    else
-      log WARN "trust extract failed for ${_ks}; trying /tmp then copy" >&2
-      trust extract --overwrite --format=java-cacerts --filter=ca-anchors --purpose server-auth /tmp/cacerts.tmp || log ERROR "Error extracting certificates for java keystore" >&2
-      cp -f /tmp/cacerts.tmp "${_ks}" || log ERROR "Error copying certificates to java keystore" >&2
+    cacerts_path=${JAVA_CERTIFICATE_FILE_LOCATION:-/etc/ssl/certs/java/cacerts}
+    if [[ -x /usr/bin/trust ]]; then
+      trust extract --overwrite --format=java-cacerts --filter=ca-anchors --purpose server-auth "${cacerts_path}" && \
+        log DEBUG "trust extract: refreshed Java keystore at ${cacerts_path}"
+
+      if [[ -x /usr/bin/keytool ]]; then
+        pass=${CERTIFICATE_FILE_PASSWORD:-changeit}
+        # Change password if passed and default one set as old
+        if [ "$pass" != "changeit" ]; then
+          chmod u+rw "${cacerts_path}"
+          log INFO "Change default keystore password: "
+          keytool -v -storepasswd -keystore "${cacerts_path}" -storepass changeit -new "$pass"
+          chmod u-w "${cacerts_path}"
+        fi
+      fi
     fi
 
     log INFO "Done"
-
-    if [[ -x /usr/bin/keytool ]]; then
-      pass=${CERTIFICATE_FILE_PASSWORD:-changeit}
-      # Change password if passed and default one set as old
-      if [ "$pass" != "changeit" ]; then
-        log INFO "Change default keystore password: "
-        chmod u+w /etc/ssl/certs/java/cacerts
-        keytool -v -storepasswd -cacerts -storepass changeit -new "$pass"
-        chmod u-w /etc/ssl/certs/java/cacerts
-      fi
-    fi
 }
 
 create_user() {

--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -59,17 +59,14 @@ load_certificates() {
     # but we can do workaround by extracting certificates from trust store and copying them to java keystore (openshift case)
     log DEBUG "Running update-ca-certificates"
 
-    if [[ "${LOG_LEVEL_EFFECTIVE^^}" == "DEBUG" ]]; then
-      update-ca-certificates -v || log WARN "Error updating CA certificates store. Try alternative method to update certificates for java keystore. " >&2
-    else
-      update-ca-certificates >/dev/null 2>&1 || log WARN "Error updating CA certificates store. Try alternative method to update certificates for java keystore. For details, run with IMAGE_LOG_LEVEL=DEBUG." >&2
-    fi
+    update-ca-certificates -v || log ERROR "Error updating CA certificates store"
 
     # Refresh Java cacerts from the trust store after system CA update (replaces Alpine's java-cacerts hook).
     cacerts_path=${JAVA_CERTIFICATE_FILE_LOCATION:-/etc/ssl/certs/java/cacerts}
     if [[ -x /usr/bin/trust ]]; then
-      trust extract --overwrite --format=java-cacerts --filter=ca-anchors --purpose server-auth "${cacerts_path}" && \
-        log DEBUG "trust extract: refreshed Java keystore at ${cacerts_path}"
+      log DEBUG "Update jks using trust tool"
+      trust extract --overwrite --format=java-cacerts --filter=ca-anchors --purpose server-auth "${cacerts_path}" || \
+        log ERROR "Error update jks using trust extract ${cacerts_path}"
 
       if [[ -x /usr/bin/keytool ]]; then
         pass=${CERTIFICATE_FILE_PASSWORD:-changeit}

--- a/images/java-21-prof/Dockerfile
+++ b/images/java-21-prof/Dockerfile
@@ -10,21 +10,18 @@ LABEL maintainer="qubership"
 
 USER root
 
-RUN apk update --no-cache
+RUN wget -O /etc/apk/keys/amazoncorretto.rsa.pub https://apk.corretto.aws/amazoncorretto.rsa.pub && \
+    echo "https://apk.corretto.aws/" >> /etc/apk/repositories
 
 RUN apk --no-cache add \
     ssl_client \
-    openjdk21-jdk \
+    amazon-corretto-21 \
+    p11-kit-trust \
     fontconfig \
     font-dejavu \
     procps-ng # top command required by diag tool
 
-# The default java-cacerts hook runs `trust extract` inside `update-ca-certificates` via run-parts
-# and can fail transiently while the system bundle is mid-update.
-# We refresh the Java keystore once after update-ca-certificates in entrypoint.sh instead.
-RUN rm -f /etc/ca-certificates/update.d/java-cacerts
-
-ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk \
+ENV JAVA_HOME=/usr/lib/jvm/java-21-amazon-corretto \
     MALLOC_ARENA_MAX=2 \
     MALLOC_MMAP_THRESHOLD_=131072 \
     MALLOC_TRIM_THRESHOLD_=131072 \
@@ -54,7 +51,7 @@ RUN mkdir -p /tmp/cert && \
     chown ${UID}:${GID} /var/lock && \
     chmod ug+rw /var/run && \
     chown ${UID}:${GID} /var/run && \
-    mkdir -p /etc/alternatives && ln -s /usr/lib/jvm/java-21-openjdk/bin/java /etc/alternatives/java && \
+    mkdir -p /etc/alternatives && ln -s /usr/lib/jvm/java-21-amazon-corretto/bin/java /etc/alternatives/java && \
     chown -R ${UID}:${GID} /etc/ca-certificates.conf && \
     mkdir -p /app/volumes/certs && \
     cp -R /etc/ssl/certs/java /app/volumes/certs && \

--- a/images/java-21-prof/Dockerfile
+++ b/images/java-21-prof/Dockerfile
@@ -30,7 +30,12 @@ ENV JAVA_HOME=/usr/lib/jvm/java-21-amazon-corretto \
     JAVA_CERTIFICATE_FILE_LOCATION=/etc/ssl/certs/java/cacerts \
     NC_DIAGNOSTIC_MODE=off
 
-RUN mkdir -p /tmp/cert && \
+RUN chown -R ${UID}:${GID} ${JAVA_HOME}/lib/security/ && \
+    mkdir -p $(dirname ${JAVA_CERTIFICATE_FILE_LOCATION}) && \
+    touch ${JAVA_CERTIFICATE_FILE_LOCATION} && \
+    rm -f ${JAVA_HOME}/lib/security/cacerts && \
+    ln -s ${JAVA_CERTIFICATE_FILE_LOCATION} ${JAVA_HOME}/lib/security/cacerts && \
+    mkdir -p /tmp/cert && \
     chmod -R ug+rw /tmp && \
     chown -R ${UID}:${GID} /tmp && \
     mkdir -p /etc/env && \

--- a/images/java-25/Dockerfile
+++ b/images/java-25/Dockerfile
@@ -10,15 +10,12 @@ LABEL maintainer="qubership"
 
 USER root
 
-RUN apk update --no-cache
+RUN wget -O /etc/apk/keys/amazoncorretto.rsa.pub https://apk.corretto.aws/amazoncorretto.rsa.pub && \
+    echo "https://apk.corretto.aws/" >> /etc/apk/repositories
 
 RUN apk --no-cache add \
-    openjdk25-jre-headless
-
-# The default java-cacerts hook runs `trust extract` inside `update-ca-certificates` via run-parts
-# and can fail transiently while the system bundle is mid-update.
-# We refresh the Java keystore once after update-ca-certificates in entrypoint.sh instead.
-RUN rm -f /etc/ca-certificates/update.d/java-cacerts
+    amazon-corretto-25 \
+    p11-kit-trust
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm \
     MALLOC_ARENA_MAX=2 \
@@ -28,7 +25,12 @@ ENV JAVA_HOME=/usr/lib/jvm/default-jvm \
     MALLOC_MMAP_MAX=65536 \
     JAVA_CERTIFICATE_FILE_LOCATION=/etc/ssl/certs/java/cacerts
 
-RUN mkdir -p /tmp/cert && \
+RUN chown -R ${UID}:${GID} ${JAVA_HOME}/lib/security/ && \
+    mkdir -p $(dirname ${JAVA_CERTIFICATE_FILE_LOCATION}) && \
+    touch ${JAVA_CERTIFICATE_FILE_LOCATION} && \
+    rm -f ${JAVA_HOME}/lib/security/cacerts && \
+    ln -s ${JAVA_CERTIFICATE_FILE_LOCATION} ${JAVA_HOME}/lib/security/cacerts && \
+    mkdir -p /tmp/cert && \
     chmod -R ug+rw /tmp && \
     chown -R ${UID}:${GID} /tmp && \
     mkdir -p /etc/env && \
@@ -51,7 +53,6 @@ RUN mkdir -p /tmp/cert && \
     chown ${UID}:${GID} /var/run && \
     chown -R ${UID}:${GID} /etc/ca-certificates.conf && \
     mkdir -p /app/volumes/certs && \
-    cp -R /etc/ssl/certs/java /app/volumes/certs && \
     find /etc/ssl/certs \( -type d -exec chmod ug+rw {} \; -exec chown ${UID}:${GID} {} \; -o -type f -exec chmod 644 {} \; -exec chown ${UID}:${GID} {} \; \) && \
     find /usr/local/share/ca-certificates/ \( -type d -exec chmod ug+rw {} \; -exec chown ${UID}:${GID} {} \; -o -type f -exec chmod 644 {} \; -exec chown ${UID}:${GID} {} \; \) && \
     find /usr/share/ca-certificates/ \( -type d -exec chmod ug+rw {} \; -exec chown ${UID}:${GID} {} \; -o -type f -exec chmod 644 {} \; -exec chown ${UID}:${GID} {} \; \) && \

--- a/images/java-25/Dockerfile
+++ b/images/java-25/Dockerfile
@@ -1,4 +1,17 @@
 ARG BASE_IMAGE=ghcr.io/netcracker/qubership-core-base:latest@sha256:b77f160cfd406124b3f1be223e82b21e742d5533638c64409e5992342587304a
+
+FROM amazoncorretto:25-alpine-jdk AS jlink
+RUN apk --no-cache add binutils
+RUN $JAVA_HOME/bin/jlink \
+    --add-modules java.se \
+    --add-modules jdk.jfr \
+    --module-path $JAVA_HOME/jmods \
+    --strip-debug \
+    --no-man-pages \
+    --no-header-files \
+    --compress=zip-6 \
+    --output /opt/jre
+
 FROM ${BASE_IMAGE}
 ARG TARGETOS
 ARG TARGETARCH
@@ -10,14 +23,12 @@ LABEL maintainer="qubership"
 
 USER root
 
-RUN wget -O /etc/apk/keys/amazoncorretto.rsa.pub https://apk.corretto.aws/amazoncorretto.rsa.pub && \
-    echo "https://apk.corretto.aws/" >> /etc/apk/repositories
-
 RUN apk --no-cache add \
-    amazon-corretto-25 \
     p11-kit-trust
 
-ENV JAVA_HOME=/usr/lib/jvm/default-jvm \
+COPY --from=jlink /opt/jre /usr/lib/jvm/java-25-amazon-corretto
+
+ENV JAVA_HOME=/usr/lib/jvm/java-25-amazon-corretto \
     MALLOC_ARENA_MAX=2 \
     MALLOC_MMAP_THRESHOLD_=131072 \
     MALLOC_TRIM_THRESHOLD_=131072 \
@@ -25,7 +36,9 @@ ENV JAVA_HOME=/usr/lib/jvm/default-jvm \
     MALLOC_MMAP_MAX=65536 \
     JAVA_CERTIFICATE_FILE_LOCATION=/etc/ssl/certs/java/cacerts
 
-RUN chown -R ${UID}:${GID} ${JAVA_HOME}/lib/security/ && \
+RUN ln -s ${JAVA_HOME}/bin/java /usr/bin/java && \
+    ln -s ${JAVA_HOME}/bin/keytool /usr/bin/keytool && \
+    chown -R ${UID}:${GID} ${JAVA_HOME}/lib/security/ && \
     mkdir -p $(dirname ${JAVA_CERTIFICATE_FILE_LOCATION}) && \
     touch ${JAVA_CERTIFICATE_FILE_LOCATION} && \
     rm -f ${JAVA_HOME}/lib/security/cacerts && \
@@ -62,4 +75,3 @@ RUN echo $BASE_IMAGE_TAG > /etc/base-image-release
 
 # Set user appuser for image run and all the following RUN, CMD and ENTRYPOINT commands
 USER ${UID}:${GID}
-

--- a/images/java-25/Dockerfile
+++ b/images/java-25/Dockerfile
@@ -3,8 +3,7 @@ ARG BASE_IMAGE=ghcr.io/netcracker/qubership-core-base:latest@sha256:b77f160cfd40
 FROM amazoncorretto:25-alpine-jdk AS jlink
 RUN apk --no-cache add binutils
 RUN $JAVA_HOME/bin/jlink \
-    --add-modules java.se \
-    --add-modules jdk.jfr \
+    --add-modules ALL-MODULE-PATH \
     --module-path $JAVA_HOME/jmods \
     --strip-debug \
     --no-man-pages \


### PR DESCRIPTION
### Summary
Migrates the Java 21 and Java 25 base images from Alpine's OpenJDK packages to **Amazon Corretto**, and reworks the certificate-loading logic in the entrypoint accordingly.

### Changes

**Java 21 (`images/java-21-prof/Dockerfile`)**
- Add the Amazon Corretto apk repository and signing key, install `amazon-corretto-21` (+ `p11-kit-trust`) in place of `openjdk21-jdk`.
- `JAVA_HOME` → `/usr/lib/jvm/java-21-amazon-corretto`.
- Symlink the JDK's `lib/security/cacerts` to the shared `JAVA_CERTIFICATE_FILE_LOCATION` so the runtime keystore is externally managed an

**Java 25 (`images/java-25/Dockerfile`)**
- Build a slim runtime with a `jlink` stage from `amazoncorretto:25-alpine-jdk` (`java.se` + `jdk.jfr`, stripped/compressed) and `COPY` it into the final image, replacing `openjdk25-jre-headless`. This image now ships a **JDK-based custom runtime instead of a JRE**.
- `JAVA_HOME` → `/usr/lib/jvm/java-25-amazon-corretto`; add `java`/`keytool` symlinks into `/usr/bin` and the same externalized `cacerts`

**Entrypoint (`images/entrypoint.sh`)**
- Simplify `load_certificates`: always run `update-ca-certificates -v`, then refresh the Java keystore via `trust extract` when `/usr/bin/trust` is present.
- Handle the optional keystore password change with `keytool -storepasswd` against the keystore file directly.
- Suppress `set -x` tracing inside `log()` and fix indentation.

**Docs (`README.md`)**
- Update Java version, dependency names, and `JAVA_HOME` values for both images.

### Notes
- Both images drop the previous `rm -f /etc/ca-certificates/update.d/java-cacerts` workaround; keystore refresh is now handled centrally in the entrypoint.
- Java 25 no longer copies `/etc/ssl/certs/java` into `/app/volumes/certs`.